### PR TITLE
ci: Improve distribution via GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,29 +22,36 @@ jobs:
   test:
     strategy:
       matrix:
-        rust:
+        include:
           # This is the minimum supported Rust version of this crate.
           # When updating this, the reminder to update the minimum supported Rust version in README.md.
-          - 1.45.2
-          - stable
-          - beta
-        include:
-          - os: ubuntu-latest
-            rust: nightly
-          - os: macos-latest
-            rust: nightly
-          - os: windows-latest
-            rust: nightly
+          - rust: 1.45.2
+          - rust: stable
+          - rust: beta
+          - rust: nightly
+          - rust: nightly
+            os: macos-latest
+          - rust: nightly
+            os: windows-latest
+          - rust: nightly
+            target: x86_64-unknown-linux-musl
     runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v2
       - uses: taiki-e/github-actions/install-rust@main
         with:
           toolchain: ${{ matrix.rust }}
-      - run: cargo install cargo-hack
-      - run: cargo test
-      - run: cargo hack check --all --feature-powerset --no-dev-deps --lib
-      - if: startsWith(matrix.rust, 'nightly') && !startsWith(matrix.os, 'windows')
+      - if: matrix.target == ''
+        run: cargo install cargo-hack
+      - if: matrix.target != ''
+        run: cargo install cross
+      - if: matrix.target != ''
+        run: cross test --target ${{ matrix.target }}
+      - if: matrix.target == ''
+        run: cargo test --all
+      - if: matrix.target == ''
+        run: cargo hack check --all --feature-powerset --no-dev-deps --lib
+      - if: startsWith(matrix.rust, 'nightly') && !startsWith(matrix.os, 'windows') && matrix.target == ''
         run: bash scripts/check-minimal-versions.sh
 
   clippy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,26 +25,30 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   upload-assets:
+    name: ${{ matrix.target }}
     if: github.repository_owner == 'taiki-e'
     needs:
       - create-release
     strategy:
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
-    runs-on: ${{ matrix.os }}
+        include:
+          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+          - target: x86_64-unknown-linux-musl
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v2
       - uses: taiki-e/github-actions/install-rust@main
       # Work around https://github.com/actions/cache/issues/403 by using GNU tar
       # instead of BSD tar.
       - name: Install GNU tar
-        if: matrix.os == 'macos-latest'
+        if: startsWith(matrix.os, 'macos')
         run: |
           brew install gnu-tar
           echo "/usr/local/opt/gnu-tar/libexec/gnubin" >> "${GITHUB_PATH}"
-      - run: ci/upload-assets.sh
+      - run: ci/upload-assets.sh ${{ matrix.target }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/upload-assets.sh
+++ b/ci/upload-assets.sh
@@ -5,40 +5,56 @@ IFS=$'\n\t'
 
 PACKAGE="parse-changelog"
 
+function error {
+  if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+    echo "::error::$*"
+  else
+    echo "error: $*" >&2
+  fi
+}
+
 cd "$(cd "$(dirname "${0}")" && pwd)"/..
 
 if [[ "${GITHUB_REF:?}" != "refs/tags/"* ]]; then
-  echo "GITHUB_REF should start with 'refs/tags/'"
+  error "GITHUB_REF should start with 'refs/tags/'"
   exit 1
 fi
 tag="${GITHUB_REF#refs/tags/}"
 
-export CARGO_PROFILE_RELEASE_LTO=true
 host=$(rustc -Vv | grep host | sed 's/host: //')
+target="${1:-"${host}"}"
+cargo="cargo"
+if [[ "${host}" != "${target}" ]]; then
+  cargo="cross"
+  cargo install cross
+fi
 
-cargo build --bin "${PACKAGE}" --release
+export CARGO_PROFILE_RELEASE_LTO=true
 
-cd target/release
+$cargo build --bin "${PACKAGE}" --release --target "${target}"
+
+assets=("${PACKAGE}-${target}.tar.gz")
+cd target/"${target}"/release
 case "${OSTYPE}" in
   linux* | darwin*)
     strip "${PACKAGE}"
-    asset="${PACKAGE}-${host}.tar.gz"
-    tar czf ../../"${asset}" "${PACKAGE}"
+    tar czf ../../"${assets[0]}" "${PACKAGE}"
     ;;
   cygwin* | msys*)
-    asset="${PACKAGE}-${host}.zip"
-    7z a ../../"${asset}" "${PACKAGE}".exe
+    assets+=("${PACKAGE}-${target}.zip")
+    tar czf ../../"${assets[0]}" "${PACKAGE}".exe
+    7z a ../../"${assets[1]}" "${PACKAGE}".exe
     ;;
   *)
-    echo "unrecognized OSTYPE: ${OSTYPE}"
+    error "unrecognized OSTYPE: ${OSTYPE}"
     exit 1
     ;;
 esac
 cd ../..
 
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
-  echo "GITHUB_TOKEN not set, skipping deploy"
+  error "GITHUB_TOKEN not set, skipping deploy"
   exit 1
 else
-  gh release upload "${tag}" "${asset}" --clobber
+  gh release upload "${tag}" "${assets[@]}" --clobber
 fi


### PR DESCRIPTION
* Distribute `*.tar.gz` file for Windows. The current Windows 10 has bsdtar by default, so this makes it easy to install cross-platform.

  ```sh
  host=$(rustc -Vv | grep host | sed 's/host: //')
  curl -LsSf https://github.com/taiki-e/parse-changelog/releases/latest/download/parse-changelog-"$host".tar.gz | tar xzf - -C ~/.cargo/bin
  ```

* Distribute x86_64-unknown-linux-musl binary.