### PR TITLE
Various optimizations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ default = ["anyhow", "structopt"]
 # Note: indexmap is public dependency.
 [dependencies]
 indexmap = { version = "1.5.2", features = ["std"] }
+memchr = "2.4"
 once_cell = "1"
 regex = "1"
 
@@ -42,3 +43,9 @@ structopt = { version = "0.3", optional = true }
 [dev-dependencies]
 easy-ext = "0.2"
 tempfile = "3"
+
+[profile.release]
+debug = true
+
+[profile.bench]
+debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ["/.*", "/tools"]
 description = """
 A simple changelog parser, written in Rust.
 """
+autobenches = false
 
 [package.metadata.docs.rs]
 all-features = true
@@ -19,7 +20,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [workspace]
 resolver = "2"
-members = ["tools/codegen"]
+members = ["benches", "tools/codegen"]
 
 [[bin]]
 name = "parse-changelog"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "bench"
+version = "0.0.0"
+authors = ["Taiki Endo <te316e89@gmail.com>"]
+edition = "2018"
+publish = false
+
+[dev-dependencies]
+parse-changelog = { path = ".." }
+
+criterion = "0.3"
+
+[[bench]]
+name = "parse"
+path = "parse.rs"
+harness = false

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dev-dependencies]
-parse-changelog = { path = ".." }
+parse-changelog = { path = "..", default-features = false }
 
 criterion = "0.3"
 

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,0 +1,12 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use parse_changelog::parse;
+
+fn parse_changelog(c: &mut Criterion) {
+    let text = include_str!("../tests/fixtures/rust.md");
+    c.bench_function("parse_changelog", |b| {
+        b.iter(|| parse(black_box(text)).unwrap());
+    });
+}
+
+criterion_group!(benches, parse_changelog);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -597,7 +597,7 @@ fn heading<'a>(
 
 fn trim(s: &str) -> &str {
     let mut count = 0;
-    while s[count..].starts_with(' ') {
+    while s.as_bytes().get(count) == Some(&b' ') {
         count += 1;
     }
     // Indents less than 4 are ignored.

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -81,13 +81,13 @@ unreleased
     for changelog in &changelogs {
         let changelog = parse(changelog).unwrap();
         assert_eq!(changelog[0].title, "0.2.0");
-        assert_eq!(trim(&changelog[0].notes), "0.2.0.");
+        assert_eq!(trim(changelog[0].notes), "0.2.0.");
 
         assert_eq!(changelog["0.2.0"].title, "0.2.0");
-        assert_eq!(trim(&changelog["0.2.0"].notes), "0.2.0.");
+        assert_eq!(trim(changelog["0.2.0"].notes), "0.2.0.");
 
         assert_eq!(changelog["0.1.0"].title, "0.1.0");
-        assert_eq!(trim(&changelog["0.1.0"].notes), "0.1.0.");
+        assert_eq!(trim(changelog["0.1.0"].notes), "0.1.0.");
     }
 }
 


### PR DESCRIPTION
This makes parse-changelog more than twice as fast as before.

Before:

```text
parse_changelog         time:   [2.3318 ms 2.3431 ms 2.3574 ms]
```

After:

```text
parse_changelog         time:   [965.72 us 969.73 us 974.69 us]                            
                        change: [-58.853% -58.554% -58.292%] (p = 0.00 < 0.05)
```