### PR TITLE
Workaround for rustdoc's rendering change

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,11 +78,11 @@
 //! Atx-style headings:
 //!
 //! ```markdown
-//! # 0.1.0
+//! ## 0.1.0
 //! ```
 //!
 //! ```markdown
-//! ## 0.1.0
+//! ### 0.1.0
 //! ```
 //!
 //! Setext-style headings:
@@ -103,11 +103,11 @@
 //! `[` and `]`) that starts with a valid version format. For example:
 //!
 //! ```markdown
-//! # [0.2.0]
+//! ## [0.2.0]
 //!
 //! description...
 //!
-//! # 0.1.0
+//! ## 0.1.0
 //!
 //! description...
 //! ```
@@ -115,7 +115,7 @@
 //! You can also include characters before the version as prefix.
 //!
 //! ```text
-//! ## Version 0.1.0
+//! ### Version 0.1.0
 //!    ^^^^^^^^
 //! ```
 //!
@@ -126,14 +126,14 @@
 //! parse it).
 //!
 //! ```text
-//! # 0.1.0 - 2020-01-01
+//! ## 0.1.0 - 2020-01-01
 //!        ^^^^^^^^^^^^^
 //! ```
 //!
 //! ## Versions
 //!
 //! ```text
-//! ## v0.1.0 -- 2020-01-01
+//! ### v0.1.0 -- 2020-01-01
 //!     ^^^^^
 //! ```
 //!
@@ -246,7 +246,7 @@ pub struct Release<'a> {
     /// The version of this release.
     ///
     /// ```text
-    /// ## Version 0.1.0 -- 2020-01-01
+    /// ### Version 0.1.0 -- 2020-01-01
     ///            ^^^^^
     /// ```
     ///
@@ -255,7 +255,7 @@ pub struct Release<'a> {
     /// The title of this release.
     ///
     /// ```text
-    /// ## Version 0.1.0 -- 2020-01-01
+    /// ### Version 0.1.0 -- 2020-01-01
     ///    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     /// ```
     ///
@@ -302,7 +302,7 @@ impl Parser {
     /// Sets the version format.
     ///
     /// ```text
-    /// ## v0.1.0 -- 2020-01-01
+    /// ### v0.1.0 -- 2020-01-01
     ///     ^^^^^
     /// ```
     ///
@@ -348,11 +348,11 @@ impl Parser {
     /// characters). For example:
     ///
     /// ```text
-    /// ## Version 0.1.0 -- 2020-01-01
+    /// ### Version 0.1.0 -- 2020-01-01
     ///    ^^^^^^^^
     /// ```
     /// ```text
-    /// ## v0.1.0 -- 2020-01-01
+    /// ### v0.1.0 -- 2020-01-01
     ///    ^
     /// ```
     ///


### PR DESCRIPTION
Source:

https://github.com/taiki-e/parse-changelog/blob/439f9035e69652657bf67fbd13cfdae578c56e48/src/lib.rs#L80-L86

[0.3.0](https://docs.rs/parse-changelog/0.3.0/parse_changelog/index.html#headings) (2021-04-12):

<img width="197" alt="0 3 0" src="https://user-images.githubusercontent.com/43724913/126608786-05010cc0-321a-45bb-9587-0da509740bc1.png">

[0.4.0](https://docs.rs/parse-changelog/0.4.0/parse_changelog/index.html#headings) (2021-07-22):

<img width="197" alt="0 4 0" src="https://user-images.githubusercontent.com/43724913/126608884-a40e2763-3ce7-4cfb-92b7-7afd57018951.png">
