### PR TITLE
Do not use regex in heading parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+- Performance improvements.
+
 ## [0.4.1] - 2021-07-22
 
 - Documentation improvements.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -639,9 +639,6 @@ fn heading<'a>(
     line_end: usize,
     lines: &mut Peekable<impl Iterator<Item = usize>>,
 ) -> Option<Heading<'a>> {
-    static ALL_EQUAL_SIGNS: Lazy<Regex> = Lazy::new(|| Regex::new("^=+$").unwrap());
-    static ALL_DASHES: Lazy<Regex> = Lazy::new(|| Regex::new("^-+$").unwrap());
-
     let line = trim(line);
     if line.starts_with('#') {
         let mut level = 0;
@@ -655,9 +652,11 @@ fn heading<'a>(
         }
     } else if let Some(&next) = lines.peek() {
         let next = trim(&text[line_end + 1..next]);
-        if ALL_EQUAL_SIGNS.is_match(next) {
+        if next.is_empty() {
+            None
+        } else if next.as_bytes().iter().all(|&b| b == b'=') {
             Some(Heading { text: line, level: 1, style: HeadingStyle::Setext })
-        } else if ALL_DASHES.is_match(next) {
+        } else if next.as_bytes().iter().all(|&b| b == b'-') {
             Some(Heading { text: line, level: 2, style: HeadingStyle::Setext })
         } else {
             None

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -95,9 +95,17 @@ unreleased
 fn failure() {
     let changelogs = [
         // Atx-style & 4 indents
-        "    ## 0.1.0\n    0.1.0.\n",
+        "    ## 0.1.0\n",
         // Setext-style & 4 indents
-        "    0.1.0\n    ==\n    0.1.0.\n",
+        "    0.1.0\n    ==\n",
+        // Setext-style & 4 indents
+        "    0.1.0\n==\n",
+        // Setext-style & 4 indents
+        "    0.1.0\n--\n",
+        // Setext-style & non-'=' char
+        "0.1.0\n==?\n",
+        // Setext-style & non-'-' char
+        "0.1.0\n--?\n",
     ];
     for changelog in &changelogs {
         assert!(parse(changelog).unwrap_err().is_parse());


### PR DESCRIPTION
This improves performance by 45-50%.

```text
atx/parse               time:   [495.10 us 496.65 us 498.31 us]                      
                        change: [-45.433% -45.093% -44.698%] (p = 0.00 < 0.05)
                        Performance has improved.

atx/parse_iter          time:   [487.15 us 488.23 us 489.35 us]                           
                        change: [-46.148% -45.786% -45.362%] (p = 0.00 < 0.05)
                        Performance has improved.

atx/parse_iter_first    time:   [6.2727 us 6.3006 us 6.3321 us]                                  
                        change: [-49.016% -48.392% -47.766%] (p = 0.00 < 0.05)
                        Performance has improved.

setext/parse            time:   [513.29 us 514.88 us 516.61 us]                         
                        change: [-46.549% -46.160% -45.690%] (p = 0.00 < 0.05)
                        Performance has improved.

setext/parse_iter       time:   [507.21 us 508.81 us 510.49 us]                              
                        change: [-47.006% -46.750% -46.493%] (p = 0.00 < 0.05)
                        Performance has improved.

setext/parse_iter_first time:   [6.6167 us 6.6416 us 6.6698 us]                                     
                        change: [-51.200% -50.529% -49.834%] (p = 0.00 < 0.05)
                        Performance has improved.
```