### PR TITLE
Switch from pico-args to lexopt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+### CLI
+
+- Fix bugs in argument parsing introduced in 0.4.5. ([#20](https://github.com/taiki-e/parse-changelog/pull/20))
+
 ## [0.4.5] - 2021-10-15
 
 - Support Rust 1.51 again. ([#19](https://github.com/taiki-e/parse-changelog/pull/19))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ required-features = ["default"]
 
 [features]
 # When using this crate as a library, we recommend disabling the default features.
-default = ["anyhow", "pico-args", "serde", "serde_json"]
+default = ["anyhow", "lexopt", "serde", "serde_json"]
 # Implements serde::Serialize trait for parse-changelog types.
 serde = ["serde-crate", "indexmap/serde-1"]
 
@@ -38,7 +38,7 @@ once_cell = "1"
 regex = "1"
 
 anyhow = { version = "1.0.34", optional = true }
-pico-args = { version = "0.4", optional = true }
+lexopt = { version = "0.2", optional = true }
 serde-crate = { package = "serde", version = "1.0.103", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }
 

--- a/README.md
+++ b/README.md
@@ -79,14 +79,12 @@ Simple changelog parser, written in Rust.
 
 Parses changelog and returns a release note for the specified version.
 
-Use -h for short descriptions and --help for more details.
-
 USAGE:
     parse-changelog [OPTIONS] <PATH> [VERSION]
 
 ARGS:
     <PATH>       Path to the changelog file (use '-' for standard input)
-    <VERSION>    Specify version (by default, select the latest release)
+    [VERSION]    Specify version (by default, select the latest release)
 
 OPTIONS:
     -t, --title                       Returns title instead of notes

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -10,7 +10,7 @@ use indexmap::IndexMap;
 fn failures() {
     parse_changelog([] as [&str; 0])
         .assert_failure()
-        .stderr_contains("free-standing argument is missing");
+        .stderr_contains("no changelog path specified");
 
     parse_changelog(["tests/fixtures/pin-project.md", "0.0.0"])
         .assert_failure()


### PR DESCRIPTION
If there are multiple flags with values, it is impossible to parse the arguments correctly using the current `pico-args`.
For example, the following command will be parsed as `--flag1 value1` and `--flag2 value2` when parsed `--flag1` first, which is not what we expect.

```text
app --flag2 --flag1 value1 value2
```
