### PR TITLE
Add --title-no-link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Note: In this file, do not use the hard wrap in the middle of a sentence for com
 
 ## [Unreleased]
 
+### CLI
+
+- Add `--title-no-link` flag. This is similar to `--title`, but removes links from the title. ([#33](https://github.com/taiki-e/parse-changelog/pull/33))
+
+### Library
+
+- Add `Release::title_no_link` method. ([#33](https://github.com/taiki-e/parse-changelog/pull/33))
+
 ## [0.5.3] - 2023-01-11
 
 - Distribute prebuilt macOS universal binary.

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ ARGS:
 
 OPTIONS:
     -t, --title                       Returns title instead of notes
+        --title-no-link               Similar to --title, but remove links from title
         --json                        Returns JSON representation of all releases in changelog
         --version-format <PATTERN>    Specify version format
         --prefix-format <PATTERN>     Specify prefix format [aliases: prefix]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -2,73 +2,81 @@ use super::*;
 
 #[test]
 fn test_extract_version_from_title() {
-    fn version(s: &str) -> &str {
+    fn version(s: &str) -> (&str, &str) {
         extract_version_from_title(s, &DEFAULT_PREFIX_FORMAT)
     }
 
-    assert_eq!(version("[1.0.0]"), "1.0.0");
-    assert_eq!(version("[1.0.0](link)"), "1.0.0");
-    assert_eq!(version("[1.0.0]()"), "1.0.0");
-    assert_eq!(version("[1.0.0][link]"), "1.0.0");
-    assert_eq!(version("[1.0.0][]"), "1.0.0");
+    assert_eq!(version("[1.0.0]"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0](link)"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0]()"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0][link]"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0][]"), ("1.0.0", ""));
 
-    assert_eq!(version("v[1.0.0]"), "1.0.0");
-    assert_eq!(version("v[1.0.0](link)"), "1.0.0");
-    assert_eq!(version("v[1.0.0]()"), "1.0.0");
-    assert_eq!(version("v[1.0.0][link]"), "1.0.0");
-    assert_eq!(version("v[1.0.0][]"), "1.0.0");
+    assert_eq!(version("v[1.0.0]"), ("1.0.0", ""));
+    assert_eq!(version("v[1.0.0](link)"), ("1.0.0", ""));
+    assert_eq!(version("v[1.0.0]()"), ("1.0.0", ""));
+    assert_eq!(version("v[1.0.0][link]"), ("1.0.0", ""));
+    assert_eq!(version("v[1.0.0][]"), ("1.0.0", ""));
 
-    assert_eq!(version("[v1.0.0]"), "1.0.0");
-    assert_eq!(version("[v1.0.0](link)"), "1.0.0");
-    assert_eq!(version("[v1.0.0]()"), "1.0.0");
-    assert_eq!(version("[v1.0.0][link]"), "1.0.0");
-    assert_eq!(version("[v1.0.0][]"), "1.0.0");
+    assert_eq!(version("[v1.0.0]"), ("1.0.0", ""));
+    assert_eq!(version("[v1.0.0](link)"), ("1.0.0", ""));
+    assert_eq!(version("[v1.0.0]()"), ("1.0.0", ""));
+    assert_eq!(version("[v1.0.0][link]"), ("1.0.0", ""));
+    assert_eq!(version("[v1.0.0][]"), ("1.0.0", ""));
 
-    assert_eq!(version("[1.0.0] 2022"), "1.0.0");
-    assert_eq!(version("[1.0.0](link) 2022"), "1.0.0");
-    assert_eq!(version("[1.0.0]() 2022"), "1.0.0");
-    assert_eq!(version("[1.0.0][link] 2022"), "1.0.0");
-    assert_eq!(version("[1.0.0][] 2022"), "1.0.0");
+    assert_eq!(version("[1.0.0] 2022"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0](link) 2022"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0]() 2022"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0][link] 2022"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0][] 2022"), ("1.0.0", ""));
 
-    assert_eq!(version("[1.0.0 2022]"), "1.0.0");
-    assert_eq!(version("[1.0.0 2022](link)"), "1.0.0");
-    assert_eq!(version("[1.0.0 2022]()"), "1.0.0");
-    assert_eq!(version("[1.0.0 2022][link]"), "1.0.0");
-    assert_eq!(version("[1.0.0 2022][]"), "1.0.0");
+    assert_eq!(version("[1.0.0 2022]"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0 2022](link)"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0 2022]()"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0 2022][link]"), ("1.0.0", ""));
+    assert_eq!(version("[1.0.0 2022][]"), ("1.0.0", ""));
 
     // unclosed '['
-    assert_eq!(version("[1.0.0"), "1.0.0");
-    assert_eq!(version("v[1.0.0"), "1.0.0");
-    assert_eq!(version("[v1.0.0"), "1.0.0");
+    assert_eq!(version("[1.0.0"), ("1.0.0", ""));
+    assert_eq!(version("v[1.0.0"), ("1.0.0", ""));
+    assert_eq!(version("[v1.0.0"), ("1.0.0", ""));
 
-    // The followings are valid links, but it is invalid or odd for our use case (version format)
-    // and will be ignored or partially unlinked for now.
-    assert_eq!(version("[1.0.0]a(link)"), "1.0.0]a(link)"); // 1.0.0a(link) in full "unlink"
-    assert_eq!(version("[1.0.0][]]"), "1.0.0][]]"); // 1.0.0] in full "unlink"
-    assert_eq!(version("[1.0.0](link)a"), "1.0.0](link)a"); // 1.0.0a in full "unlink"
+    assert_eq!(version("[1.0.0]a(link)"), ("1.0.0", "a(link)"));
+    assert_eq!(version("[1.0.0][]]"), ("1.0.0", "]"));
+    assert_eq!(version("[1.0.0](link)a"), ("1.0.0", "a"));
 }
 
 // See also "Note" section in `unlink` function.
 #[test]
 fn test_unlink() {
-    assert_eq!(unlink("[1.0.0]"), "1.0.0");
-    assert_eq!(unlink("[1.0.0](link)"), "1.0.0");
-    assert_eq!(unlink("[1.0.0]()"), "1.0.0");
-    assert_eq!(unlink("[1.0.0][link]"), "1.0.0");
-    assert_eq!(unlink("[1.0.0][]"), "1.0.0");
+    assert_eq!(unlink("[1.0.0]"), ("1.0.0", ""));
+    assert_eq!(unlink("[1.0.0](link)"), ("1.0.0", ""));
+    assert_eq!(unlink("[1.0.0]()"), ("1.0.0", ""));
+    assert_eq!(unlink("[1.0.0][link]"), ("1.0.0", ""));
+    assert_eq!(unlink("[1.0.0][]"), ("1.0.0", ""));
 
     // Link without trailing ']': e.g., [1.0.0 2022-01-01]
-    assert_eq!(unlink("[1.0.0"), "1.0.0");
-    assert_eq!(unlink("[1.0.0(a)"), "1.0.0(a)");
+    assert_eq!(unlink("[1.0.0"), ("1.0.0", ""));
+    assert_eq!(unlink("[1.0.0(a)"), ("1.0.0(a)", ""));
 
     // Link without leading '[': e.g., [Version 1.0.0]
-    assert_eq!(unlink("1.0.0]"), "1.0.0");
-    assert_eq!(unlink("1.0.0](link)"), "1.0.0");
-    assert_eq!(unlink("1.0.0][link]"), "1.0.0");
+    assert_eq!(unlink("1.0.0]"), ("1.0.0", ""));
+    assert_eq!(unlink("1.0.0](link)"), ("1.0.0", ""));
+    assert_eq!(unlink("1.0.0][link]"), ("1.0.0", ""));
 
-    // The followings are valid links, but it is invalid or odd for our use case (version format)
-    // and will be ignored or partially unlinked for now.
-    assert_eq!(unlink("[1.0.0]a(link)"), "1.0.0]a(link)"); // 1.0.0a(link) in full "unlink"
-    assert_eq!(unlink("[1.0.0][]]"), "1.0.0][]]"); // 1.0.0] in full "unlink"
-    assert_eq!(unlink("[1.0.0](link)a"), "1.0.0](link)a"); // 1.0.0a in full "unlink"
+    assert_eq!(unlink("[1.0.0]a(link)"), ("1.0.0", "a(link)"));
+    assert_eq!(unlink("[1.0.0][]]"), ("1.0.0", "]"));
+    assert_eq!(unlink("[1.0.0](link)a"), ("1.0.0", "a"));
+}
+
+#[test]
+fn test_full_unlink() {
+    assert_eq!(full_unlink("[1.0.0]"), "1.0.0");
+    assert_eq!(full_unlink("[1.0.0]()"), "1.0.0");
+    assert_eq!(full_unlink("[1.0.0](link)"), "1.0.0");
+    assert_eq!(full_unlink("[1.0.0][]"), "1.0.0");
+    assert_eq!(full_unlink("[1.0.0][link]"), "1.0.0");
+    assert_eq!(full_unlink("[1.0.0][link1][a](link2)"), "1.0.0a");
+    assert_eq!(full_unlink("[1.0.0][link1][a][link2]"), "1.0.0a");
+    assert_eq!(full_unlink("v [1.0.0][link1][a](link2) [b][link3] [c] (d)"), "v 1.0.0a b c (d)");
 }


### PR DESCRIPTION
Closes #32 


### CLI

- Add `--title-no-link` flag. This is similar to `--title`, but removes links from the title.

### Library

- Add `Release::title_no_link` method.