### PR TITLE
Various optimizations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ fn try_main() -> Result<()> {
     }
 
     let text = if args.path == "-" {
-        let mut buf = String::new();
+        let mut buf = String::with_capacity(128);
         io::stdin().read_to_string(&mut buf).context("failed to read standard input")?;
         buf
     } else {


### PR DESCRIPTION
On AArch64 macOS (Apple M1 Pro):

```
parse_changelog_atx/parse
                        time:   [480.53 µs 482.00 µs 483.64 µs]
                        thrpt:  [1.3858 GiB/s 1.3905 GiB/s 1.3948 GiB/s]
                 change:
                        time:   [-13.191% -12.752% -12.302%] (p = 0.00 < 0.05)
                        thrpt:  [+14.028% +14.616% +15.195%]
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  12 (12.00%) high mild
  3 (3.00%) high severe
parse_changelog_atx/parse_custom
                        time:   [480.94 µs 483.24 µs 486.14 µs]
                        thrpt:  [1.3787 GiB/s 1.3869 GiB/s 1.3936 GiB/s]
                 change:
                        time:   [-13.335% -12.880% -12.433%] (p = 0.00 < 0.05)
                        thrpt:  [+14.198% +14.784% +15.387%]
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  3 (3.00%) high mild
  11 (11.00%) high severe
parse_changelog_atx/parse_iter
                        time:   [477.82 µs 479.57 µs 481.57 µs]
                        thrpt:  [1.3918 GiB/s 1.3976 GiB/s 1.4027 GiB/s]
                 change:
                        time:   [-14.296% -13.476% -12.840%] (p = 0.00 < 0.05)
                        thrpt:  [+14.732% +15.574% +16.681%]
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  6 (6.00%) high mild
  11 (11.00%) high severe
parse_changelog_atx/parse_iter_first
                        time:   [8.4009 µs 8.4278 µs 8.4591 µs]
                        thrpt:  [79.231 GiB/s 79.525 GiB/s 79.780 GiB/s]
                 change:
                        time:   [-18.360% -17.962% -17.573%] (p = 0.00 < 0.05)
                        thrpt:  [+21.320% +21.895% +22.489%]
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  6 (6.00%) high mild
  11 (11.00%) high severe

parse_changelog_setext/parse
                        time:   [511.46 µs 513.32 µs 515.42 µs]
                        thrpt:  [1.3153 GiB/s 1.3207 GiB/s 1.3255 GiB/s]
                 change:
                        time:   [-12.895% -12.464% -12.020%] (p = 0.00 < 0.05)
                        thrpt:  [+13.662% +14.239% +14.803%]
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  8 (8.00%) high mild
  12 (12.00%) high severe
parse_changelog_setext/parse_custom
                        time:   [511.52 µs 513.34 µs 515.40 µs]
                        thrpt:  [1.3154 GiB/s 1.3206 GiB/s 1.3253 GiB/s]
                 change:
                        time:   [-12.806% -12.437% -12.061%] (p = 0.00 < 0.05)
                        thrpt:  [+13.716% +14.203% +14.687%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  10 (10.00%) high mild
parse_changelog_setext/parse_iter
                        time:   [508.24 µs 509.92 µs 511.84 µs]
                        thrpt:  [1.3245 GiB/s 1.3295 GiB/s 1.3339 GiB/s]
                 change:
                        time:   [-12.720% -12.368% -12.016%] (p = 0.00 < 0.05)
                        thrpt:  [+13.658% +14.113% +14.573%]
                        Performance has improved.
Found 18 outliers among 100 measurements (18.00%)
  8 (8.00%) high mild
  10 (10.00%) high severe
parse_changelog_setext/parse_iter_first
                        time:   [8.9967 µs 9.0329 µs 9.0758 µs]
                        thrpt:  [74.697 GiB/s 75.052 GiB/s 75.354 GiB/s]
                 change:
                        time:   [-17.895% -17.521% -17.104%] (p = 0.00 < 0.05)
                        thrpt:  [+20.633% +21.242% +21.796%]
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  12 (12.00%) high mild
  4 (4.00%) high severe
```

On x86_64 macOS (Intel Core i7-9750H, Coffee Lake):

```
Benchmarking parse_changelog_atx/parse: Collecting 100 samples in estimated 6.51parse_changelog_atx/parse
                        time:   [643.67 µs 644.70 µs 645.71 µs]
                        thrpt:  [1.0380 GiB/s 1.0396 GiB/s 1.0413 GiB/s]
                 change:
                        time:   [-15.342% -14.664% -14.002%] (p = 0.00 < 0.05)
                        thrpt:  [+16.282% +17.184% +18.122%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  8 (8.00%) high mild
  2 (2.00%) high severe
Benchmarking parse_changelog_atx/parse_custom: Collecting 100 samples in estimatparse_changelog_atx/parse_custom
                        time:   [649.37 µs 651.87 µs 654.85 µs]
                        thrpt:  [1.0235 GiB/s 1.0282 GiB/s 1.0321 GiB/s]
                 change:
                        time:   [-15.034% -14.189% -13.405%] (p = 0.00 < 0.05)
                        thrpt:  [+15.480% +16.535% +17.694%]
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  8 (8.00%) high mild
  7 (7.00%) high severe
Benchmarking parse_changelog_atx/parse_iter: Collecting 100 samples in estimatedparse_changelog_atx/parse_iter
                        time:   [651.53 µs 653.02 µs 654.47 µs]
                        thrpt:  [1.0241 GiB/s 1.0263 GiB/s 1.0287 GiB/s]
                 change:
                        time:   [-15.970% -14.618% -13.281%] (p = 0.00 < 0.05)
                        thrpt:  [+15.315% +17.121% +19.005%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe
Benchmarking parse_changelog_atx/parse_iter_first: Collecting 100 samples in estparse_changelog_atx/parse_iter_first
                        time:   [13.236 µs 13.347 µs 13.500 µs]
                        thrpt:  [49.647 GiB/s 50.216 GiB/s 50.636 GiB/s]
                 change:
                        time:   [-8.7472% -7.7702% -6.6708%] (p = 0.00 < 0.05)
                        thrpt:  [+7.1476% +8.4248% +9.5856%]
                        Performance has improved.

Benchmarking parse_changelog_setext/parse: Collecting 100 samples in estimated 7parse_changelog_setext/parse
                        time:   [708.50 µs 709.65 µs 710.71 µs]
                        thrpt:  [976.77 MiB/s 978.24 MiB/s 979.82 MiB/s]
                 change:
                        time:   [-13.588% -13.133% -12.701%] (p = 0.00 < 0.05)
                        thrpt:  [+14.549% +15.118% +15.725%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low severe
  5 (5.00%) low mild
  3 (3.00%) high severe
Benchmarking parse_changelog_setext/parse_custom: Collecting 100 samples in estiparse_changelog_setext/parse_custom
                        time:   [701.94 µs 704.14 µs 706.74 µs]
                        thrpt:  [982.27 MiB/s 985.89 MiB/s 988.98 MiB/s]
                 change:
                        time:   [-13.615% -13.191% -12.737%] (p = 0.00 < 0.05)
                        thrpt:  [+14.597% +15.196% +15.761%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high severe
Benchmarking parse_changelog_setext/parse_iter: Collecting 100 samples in estimaparse_changelog_setext/parse_iter
                        time:   [698.20 µs 700.48 µs 703.55 µs]
                        thrpt:  [986.72 MiB/s 991.04 MiB/s 994.28 MiB/s]
                 change:
                        time:   [-13.795% -13.042% -12.074%] (p = 0.00 < 0.05)
                        thrpt:  [+13.733% +14.998% +16.003%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe
Benchmarking parse_changelog_setext/parse_iter_first: Collecting 100 samples in parse_changelog_setext/parse_iter_first
                        time:   [14.320 µs 14.411 µs 14.513 µs]
                        thrpt:  [46.713 GiB/s 47.044 GiB/s 47.343 GiB/s]
                 change:
                        time:   [-13.409% -12.800% -12.221%] (p = 0.00 < 0.05)
                        thrpt:  [+13.923% +14.679% +15.485%]
                        Performance has improved.
Found 19 outliers among 100 measurements (19.00%)
  2 (2.00%) low severe
  7 (7.00%) low mild
  2 (2.00%) high mild
  8 (8.00%) high severe
```